### PR TITLE
Improve header on public page

### DIFF
--- a/app/ties/spieltage-client.tsx
+++ b/app/ties/spieltage-client.tsx
@@ -423,7 +423,7 @@ export function SpieltageClient({ accessCode, seasonId: propSeasonId }: Spieltag
             </div>
             <nav className="flex items-center">
               <a href="#" className="border-b-2 border-blue-500 px-4 py-6 text-sm font-medium text-white">
-                {seasonName ? `${seasonName} - Spieltage` : 'Spieltage'}
+                {seasonName ? seasonName : t("matchDays")}
               </a>
             </nav>
           </div>
@@ -436,7 +436,6 @@ export function SpieltageClient({ accessCode, seasonId: propSeasonId }: Spieltag
               className="border-gray-400 bg-transparent text-white hover:bg-white hover:text-gray-900 transition-colors"
             >
               <LogOut className="mr-2 h-4 w-4" />
-              {t("changeSeason")}
             </Button>
           </div>
         </div>

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -12,7 +12,6 @@ export const translations = {
     close: "Schließen",
     logout: "Abmelden",
     exit: "Beenden",
-    changeSeason: "Saison wechseln",
 
     // Auth
     login: "Anmelden",
@@ -39,6 +38,7 @@ export const translations = {
     administrator: "Administrator?",
     loginHere: "Hier anmelden",
     demoAccessCode: "Demo-Zugangscode:",
+    matchDays: "Spieltage",
 
     // Spieltage
     upcomingMatches: "Kommende Spieltage",
@@ -256,7 +256,6 @@ export const translations = {
     close: "Close",
     logout: "Logout",
     exit: "Exit",
-    changeSeason: "Change Season",
 
     // Auth
     login: "Login",
@@ -283,6 +282,7 @@ export const translations = {
     administrator: "Administrator?",
     loginHere: "Login here",
     demoAccessCode: "Demo access code:",
+    matchDays: "Match days",
 
     // Spieltage
     upcomingMatches: "Upcoming Matches",


### PR DESCRIPTION
Remove text from logout button. The symbol exaplains the functions and the width of the screen now matches better on mobile. Also the second line of the header text was removed and "matchDays" was added to i18n.

Fixes #19